### PR TITLE
PAYARA-2377 fixed race condition in JMS test

### DIFF
--- a/jms/send-receive/src/test/java/org/javaee7/jms/send/receive/mdb/ReceptionSynchronizer.java
+++ b/jms/send-receive/src/test/java/org/javaee7/jms/send/receive/mdb/ReceptionSynchronizer.java
@@ -56,6 +56,8 @@ public class ReceptionSynchronizer {
         synchronized (barrier) {
             if (barrier.containsKey(m)) {
                 latch = barrier.get(m);
+            } else {
+                barrier.put(m, new CountDownLatch(0));
             }
         }
         if (latch != null) {
@@ -85,11 +87,6 @@ public class ReceptionSynchronizer {
         synchronized (barrier) {
             if (barrier.containsKey(method)) {
                 latch = barrier.get(method);
-                if (latch.getCount() == 0) {
-                    throw new IllegalStateException("The invocation already happened");
-                } else {
-                    throw new IllegalStateException("Sorry, I only serve the first one");
-                }
             } else {
                 latch = new CountDownLatch(1);
                 barrier.put(method, latch);
@@ -99,5 +96,4 @@ public class ReceptionSynchronizer {
             throw new AssertionError("Expected method has not been invoked in " + timeoutInMillis + "ms");
         }
     }
-
 }


### PR DESCRIPTION
fixed a race condition when the method is invoked too quickly and
is never registered as being run, thus making the test wait forever