### PR TITLE
AC-37 Update payara arquillian dependencies and fix tests for 4 JDK7

### DIFF
--- a/jpa/listeners-injection/src/test/java/org/javaee7/jpa/listeners/JpaListenerInjectionTest.java
+++ b/jpa/listeners-injection/src/test/java/org/javaee7/jpa/listeners/JpaListenerInjectionTest.java
@@ -5,11 +5,11 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.AbstractMap;
 import java.util.List;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.javaee7.Parameter;
 import org.javaee7.ParameterRule;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -35,18 +35,18 @@ public class JpaListenerInjectionTest {
                 .addAsResource("META-INF/load.sql");
     }
 
-    public static final List<ImmutablePair<String, Integer>> movies = asList(
-            new ImmutablePair<>("The Matrix", 60),
-            new ImmutablePair<>("The Lord of The Rings", 70),
-            new ImmutablePair<>("Inception", 80),
-            new ImmutablePair<>("The Shining", 90)
+    public static final List<AbstractMap.SimpleImmutableEntry<String, Integer>> movies = asList(
+            new AbstractMap.SimpleImmutableEntry<>("The Matrix", 60),
+            new AbstractMap.SimpleImmutableEntry<>("The Lord of The Rings", 70),
+            new AbstractMap.SimpleImmutableEntry<>("Inception", 80),
+            new AbstractMap.SimpleImmutableEntry<>("The Shining", 90)
     );
 
     @Rule
-    public ParameterRule<ImmutablePair<String, Integer>> rule = new ParameterRule<>(movies);
+    public ParameterRule<AbstractMap.SimpleImmutableEntry<String, Integer>> rule = new ParameterRule<>(movies);
 
     @Parameter
-    private ImmutablePair<String, Integer> expectedMovie;
+    private AbstractMap.SimpleImmutableEntry<String, Integer> expectedMovie;
 
     @Inject
     private MovieBean bean;
@@ -54,8 +54,8 @@ public class JpaListenerInjectionTest {
     @Test
     public void should_provide_movie_rating_via_jpa_listener_injection() {
         // Given
-        Movie movie = bean.getMovieByName(expectedMovie.getLeft());
+        Movie movie = bean.getMovieByName(expectedMovie.getKey());
 
-        assertThat(movie.getRating(), is(equalTo(expectedMovie.getRight())));
+        assertThat(movie.getRating(), is(equalTo(expectedMovie.getValue())));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>payara-client-ee7</artifactId>
-                <version>1.0.Beta3</version>
+                <version>1.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -433,8 +433,8 @@
                 <!-- The actual Arquillian connector -->
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>arquillian-payara-server-4-managed</artifactId>
-                    <version>1.0.Beta3</version>
+                    <artifactId>arquillian-payara-server-managed</artifactId>
+                    <version>1.2</version>
                 </dependency>
             </dependencies>
 
@@ -516,22 +516,8 @@
                 <!-- The Arquillian connector -->
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>arquillian-payara-micro-5-managed</artifactId>
-                    <version>1.0.Beta3</version>
-                    <scope>test</scope>
-                </dependency>
-
-                <!-- WebSocket client dependencies -->
-                <dependency>
-                    <groupId>org.glassfish.tyrus</groupId>
-                    <artifactId>tyrus-client</artifactId>
-                    <version>1.13</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.glassfish.tyrus</groupId>
-                    <artifactId>tyrus-container-grizzly-client</artifactId>
-                    <version>1.13</version>
+                    <artifactId>arquillian-payara-micro-managed</artifactId>
+                    <version>1.2</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -640,8 +626,8 @@
                 <!-- The actual Arquillian connector -->
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>arquillian-payara-server-4-remote</artifactId>
-                    <version>1.0.Beta3</version>
+                    <artifactId>arquillian-payara-server-remote</artifactId>
+                    <version>1.2</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -705,7 +691,7 @@
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>payara-micro-remote</artifactId>
-                    <version>1.0.Beta4-SNAPSHOT</version>
+                    <version>1.2</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -747,7 +733,7 @@
                                 <artifactItem>
                                     <groupId>fish.payara.arquillian</groupId>
                                     <artifactId>payara-micro-deployer</artifactId>
-                                    <version>1.0.Beta4-SNAPSHOT</version>
+                                    <version>1.2</version>
                                     <type>war</type>
                                 </artifactItem>
                             </artifactItems>

--- a/servlet/security-clientcert-parent/pom.xml
+++ b/servlet/security-clientcert-parent/pom.xml
@@ -11,27 +11,7 @@
     
     <modules>
         <module>security-clientcert</module>
+        <module>security-clientcert-common-name</module>
     </modules>
-    
-    <profiles>
-        <profile>
-            <id>payara-server-remote</id>
-            <modules>
-                <module>security-clientcert-common-name</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>payara-server-managed</id>
-            <modules>
-                <module>security-clientcert-common-name</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>payara5</id>
-            <modules>
-                <module>security-clientcert-common-name</module>
-            </modules>
-        </profile>
-    </profiles>
     
 </project>

--- a/servlet/security-clientcert-parent/security-clientcert-common-name/pom.xml
+++ b/servlet/security-clientcert-parent/security-clientcert-common-name/pom.xml
@@ -40,25 +40,25 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
+            <id>payara4</id>
+            <properties>
+                <skipServletClientCertificate>true</skipServletClientCertificate>
+            </properties>
+        </profile>
+        <profile>
+            <id>payara-server-emebedded</id>
+            <properties>
+                <skipServletClientCertificate>true</skipServletClientCertificate>
+            </properties>
+        </profile>
+        <profile>
             <id>stable</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <!-- Bug to do with npn with this JDK version (_192) causes this, awaiting external fix tracked 
-                                by QA-138 -->
-                                <exclude>org.javaee7.servlet.security.clientcert.SecureServletWithCommonNameTest</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+            <properties>
+                <skipServletClientCertificate>true</skipServletClientCertificate>
+            </properties>
         </profile>
     </profiles>
     


### PR DESCRIPTION
Use 1.2 rather than old Beta versions, use AbstractMap.SimpleImmutableEntry rather than class from Apache commons, and fix profiles so that feature not in 4 doesn't run.

Side note: said test (client cert common name) is a Payara specific feature, it probably should be moved to Payara Samples...